### PR TITLE
feat(database): set up local multi-database environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  mongodb:
+    image: mongo:7
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: mongo
+      MONGO_INITDB_ROOT_PASSWORD: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  postgres_data:
+  mongo_data:


### PR DESCRIPTION
Branch: feat/database-setup -> develop

Description:

This pull request introduces the docker-compose setup to provide a local, containerized environment for PostgreSQL and MongoDB. This is a crucial step for the multi-database architecture outlined in the project scope.

Key Changes:

Docker Compose Configuration: A docker-compose.yml file has been added to define the database services.

PostgreSQL Service:

Uses postgres:15 image.
Configured with POSTGRES_DB, POSTGRES_USER, and POSTGRES_PASSWORD environment variables.
Maps host port 5432 to container port 5432.
Utilizes a named volume (postgres_data) for data persistence.

MongoDB Service:

Uses mongo:7 image.
Configured with MONGO_INITDB_ROOT_USERNAME and MONGO_INITDB_ROOT_PASSWORD environment variables.
Maps host port 27017 to container port 27017.
Utilizes a named volume (mongo_data) for data persistence.

This setup enables developers to easily spin up the required database instances for local development and testing, significantly streamlining the development workflow.